### PR TITLE
feat(tests): add repeatable asset testing (model, migration, controller, routes, view)

### DIFF
--- a/app/Http/Controllers/AssetTestController.php
+++ b/app/Http/Controllers/AssetTestController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Asset;
+use App\Models\AssetTest;
+use Illuminate\Http\Request;
+
+class AssetTestController extends Controller
+{
+    public function index(Asset $asset)
+    {
+        $tests = $asset->tests()->latest('tested_at')->get();
+
+        // Derive quick “failed components” list for UI
+        $failed = $asset->tests()
+            ->where('result','fail')
+            ->latest('tested_at')
+            ->get()
+            ->groupBy('component')
+            ->keys();
+
+        return view('hardware.tests.index', compact('asset','tests','failed'));
+    }
+
+    public function store(Request $request, Asset $asset)
+    {
+        $validated = $request->validate([
+            'component' => 'required|string|max:255',
+            'result'    => 'required|in:pass,fail,n_a',
+            'comment'   => 'nullable|string|max:2000',
+            'tested_at' => 'nullable|date',
+        ]);
+
+        $asset->tests()->create([
+            'user_id'   => optional($request->user())->id,
+            'component' => $validated['component'],
+            'result'    => $validated['result'],
+            'comment'   => $validated['comment'] ?? null,
+            'tested_at' => $validated['tested_at'] ?? now(),
+        ]);
+
+        return redirect()->route('asset-tests.index', $asset->id)
+            ->with('success','Test opgeslagen');
+    }
+}

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -763,6 +763,16 @@ class Asset extends Depreciable
     }
 
     /**
+     * Asset repeatable tests.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function tests()
+    {
+        return $this->hasMany(\App\Models\AssetTest::class);
+    }
+
+    /**
      * Get user who created the item
      *
      * @author [A. Gianotto] [<snipe@snipe.net>]

--- a/app/Models/AssetTest.php
+++ b/app/Models/AssetTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AssetTest extends Model
+{
+    protected $fillable = [
+        'asset_id','user_id','component','result','comment','tested_at'
+    ];
+
+    public function asset()
+    {
+        return $this->belongsTo(\App\Models\Asset::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(\App\Models\User::class);
+    }
+}

--- a/database/migrations/2025_08_09_000000_create_asset_tests_table.php
+++ b/database/migrations/2025_08_09_000000_create_asset_tests_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('asset_tests', function (Blueprint $table) {
+            $table->id();
+
+            // Foreign keys: keep types compatible with Snipe-IT core
+            $table->unsignedBigInteger('asset_id');
+            $table->foreign('asset_id')->references('id')->on('assets')->onDelete('cascade');
+
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
+
+            // Test data
+            $table->string('component');                 // e.g. keyboard, hdmi, wifi
+            $table->enum('result', ['pass','fail','n_a']);
+            $table->text('comment')->nullable();
+            $table->timestamp('tested_at')->useCurrent();
+
+            $table->timestamps();
+
+            // Helpful index
+            $table->index(['asset_id','tested_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('asset_tests');
+    }
+};

--- a/resources/views/hardware/tests/index.blade.php
+++ b/resources/views/hardware/tests/index.blade.php
@@ -1,0 +1,67 @@
+@extends('layouts/default')
+
+@section('content')
+<div class="container">
+    <h1>Tests — {{ $asset->name }} (ID: {{ $asset->id }})</h1>
+
+    @if($failed->count() > 0)
+        <div class="alert alert-danger" role="alert" style="margin:12px 0;">
+            <strong>Mislukte tests (laatste run per component):</strong>
+            {{ $failed->implode(', ') }}
+        </div>
+    @endif
+
+    <form action="{{ route('asset-tests.store', $asset->id) }}" method="POST" style="margin:16px 0;">
+        @csrf
+        <div style="display:flex;gap:12px;flex-wrap:wrap;align-items:flex-end;">
+            <div>
+                <label>Component</label>
+                <input type="text" name="component" required class="form-control" placeholder="keyboard / hdmi / wifi">
+            </div>
+            <div>
+                <label>Resultaat</label>
+                <select name="result" required class="form-control">
+                    <option value="pass">✔ Pass</option>
+                    <option value="fail">✖ Fail</option>
+                    <option value="n_a">N.v.t.</option>
+                </select>
+            </div>
+            <div>
+                <label>Opmerking</label>
+                <input type="text" name="comment" class="form-control" placeholder="optioneel">
+            </div>
+            <div>
+                <label>Datum/Tijd</label>
+                <input type="datetime-local" name="tested_at" class="form-control">
+            </div>
+            <div>
+                <button class="btn btn-primary" type="submit">Toevoegen</button>
+            </div>
+        </div>
+    </form>
+
+    <h3>Geschiedenis</h3>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Datum</th>
+                <th>Component</th>
+                <th>Resultaat</th>
+                <th>Operator</th>
+                <th>Opmerking</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach($tests as $t)
+            <tr>
+                <td>{{ \Carbon\Carbon::parse($t->tested_at)->format('Y-m-d H:i') }}</td>
+                <td>{{ $t->component }}</td>
+                <td>{{ strtoupper($t->result) }}</td>
+                <td>{{ optional($t->user)->name ?? '—' }}</td>
+                <td>{{ $t->comment ?? '—' }}</td>
+            </tr>
+        @endforeach
+        </tbody>
+    </table>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\StatuslabelsController;
 use App\Http\Controllers\SuppliersController;
 use App\Http\Controllers\ViewAssetsController;
+use App\Http\Controllers\AssetTestController;
 use App\Livewire\Importer;
 use App\Models\ReportTemplate;
 use Illuminate\Support\Facades\Route;
@@ -703,6 +704,11 @@ Route::withoutMiddleware(['web'])->get(
     '/health',
     [HealthController::class, 'get']
 )->name('health');
+Route::middleware(['auth'])->group(function () {
+    Route::get('/hardware/{asset}/tests', [AssetTestController::class, 'index'])->name('asset-tests.index');
+    Route::post('/hardware/{asset}/tests', [AssetTestController::class, 'store'])->name('asset-tests.store');
+});
+
 
 
 Route::middleware(['auth'])->get(


### PR DESCRIPTION
## Summary
- add asset_tests table migration and model to record repeatable tests
- expose asset tests via controller, routes, and Blade view
- connect Asset model with tests relationship

## Testing
- `vendor/bin/phpunit` *(fails: .env.testing file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6897a4689980832db6a82d578a377874