### PR TITLE
feat: repeatable asset test runs (DB+API+UI+tests)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -199,6 +199,11 @@ CSV_ESCAPE_FORMULAS=true
 LIVEWIRE_URL_PREFIX=null
 
 # --------------------------------------------
+# OPTIONAL: TEST RUNS
+# --------------------------------------------
+TEST_RUNS_AUTO_COMPLETE=false
+
+# --------------------------------------------
 # OPTIONAL: HASHING
 # --------------------------------------------
 HASHING_DRIVER='bcrypt'

--- a/app/Http/Controllers/Api/AssetTestRunsController.php
+++ b/app/Http/Controllers/Api/AssetTestRunsController.php
@@ -30,7 +30,15 @@ class AssetTestRunsController extends Controller
             'started_at' => now(),
             'finished_at' => $request->finished_at,
         ]);
-        return response()->json($run, 201);
+
+        foreach (AssetTestItem::COMPONENTS as $component) {
+            $run->items()->create([
+                'component' => $component,
+                'status' => 'na',
+            ]);
+        }
+
+        return response()->json($run->load('items'), 201);
     }
 
     public function show(AssetTestRun $run)

--- a/app/Http/Controllers/Api/AssetTestRunsController.php
+++ b/app/Http/Controllers/Api/AssetTestRunsController.php
@@ -23,7 +23,7 @@ class AssetTestRunsController extends Controller
         $this->authorize('create', AssetTestRun::class);
         $run = $asset->testRuns()->create([
             'user_id' => auth()->id(),
-            'test_type' => $request->test_type,
+            'test_type' => $request->input('test_type', 'laptop'),
             'status' => $request->status ?? 'in_progress',
             'os_version' => $request->os_version,
             'notes' => $request->notes,

--- a/app/Http/Controllers/Api/AssetTestRunsController.php
+++ b/app/Http/Controllers/Api/AssetTestRunsController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\AssetTestItemRequest;
+use App\Http\Requests\AssetTestRunRequest;
+use App\Models\Asset;
+use App\Models\AssetTestItem;
+use App\Models\AssetTestRun;
+use Illuminate\Http\Request;
+
+class AssetTestRunsController extends Controller
+{
+    public function index(Asset $asset)
+    {
+        $this->authorize('viewAny', AssetTestRun::class);
+        return response()->json($asset->testRuns()->with('items')->latest()->get());
+    }
+
+    public function store(AssetTestRunRequest $request, Asset $asset)
+    {
+        $this->authorize('create', AssetTestRun::class);
+        $run = $asset->testRuns()->create([
+            'user_id' => auth()->id(),
+            'os_version' => $request->os_version,
+            'notes' => $request->notes,
+            'started_at' => $request->started_at,
+            'finished_at' => $request->finished_at,
+        ]);
+        return response()->json($run, 201);
+    }
+
+    public function show(AssetTestRun $run)
+    {
+        $this->authorize('view', $run);
+        return response()->json($run->load('items'));
+    }
+
+    public function update(AssetTestRunRequest $request, AssetTestRun $run)
+    {
+        $this->authorize('update', $run);
+        $run->update($request->validated());
+        return response()->json($run);
+    }
+
+    public function destroy(AssetTestRun $run)
+    {
+        $this->authorize('delete', $run);
+        $run->delete();
+        return response()->json([], 204);
+    }
+
+    public function items(AssetTestRun $run)
+    {
+        $this->authorize('view', $run);
+        return response()->json($run->items);
+    }
+
+    public function storeItem(AssetTestItemRequest $request, AssetTestRun $run)
+    {
+        $this->authorize('update', $run);
+        $item = $run->items()->create($request->validated());
+        return response()->json($item, 201);
+    }
+
+    public function updateItem(AssetTestItemRequest $request, AssetTestRun $run, AssetTestItem $item)
+    {
+        $this->authorize('update', $run);
+        $item->update($request->validated());
+        return response()->json($item);
+    }
+}

--- a/app/Http/Controllers/Api/AssetTestRunsController.php
+++ b/app/Http/Controllers/Api/AssetTestRunsController.php
@@ -27,7 +27,7 @@ class AssetTestRunsController extends Controller
             'status' => $request->status ?? 'in_progress',
             'os_version' => $request->os_version,
             'notes' => $request->notes,
-            'started_at' => $request->started_at,
+            'started_at' => now(),
             'finished_at' => $request->finished_at,
         ]);
         return response()->json($run, 201);
@@ -42,7 +42,7 @@ class AssetTestRunsController extends Controller
     public function update(AssetTestRunRequest $request, AssetTestRun $run)
     {
         $this->authorize('update', $run);
-        $run->update($request->validated());
+        $run->update($request->safe()->except('started_at'));
         return response()->json($run);
     }
 

--- a/app/Http/Controllers/Api/AssetTestRunsController.php
+++ b/app/Http/Controllers/Api/AssetTestRunsController.php
@@ -31,10 +31,13 @@ class AssetTestRunsController extends Controller
             'finished_at' => $request->finished_at,
         ]);
 
+        $items = $request->input('items', []);
         foreach (AssetTestItem::COMPONENTS as $component) {
+            $data = $items[$component] ?? [];
             $run->items()->create([
                 'component' => $component,
-                'status' => 'na',
+                'status' => $data['status'] ?? 'na',
+                'notes' => $data['notes'] ?? null,
             ]);
         }
 

--- a/app/Http/Controllers/Api/AssetTestRunsController.php
+++ b/app/Http/Controllers/Api/AssetTestRunsController.php
@@ -23,6 +23,8 @@ class AssetTestRunsController extends Controller
         $this->authorize('create', AssetTestRun::class);
         $run = $asset->testRuns()->create([
             'user_id' => auth()->id(),
+            'test_type' => $request->test_type,
+            'status' => $request->status ?? 'in_progress',
             'os_version' => $request->os_version,
             'notes' => $request->notes,
             'started_at' => $request->started_at,

--- a/app/Http/Controllers/AssetTestRunController.php
+++ b/app/Http/Controllers/AssetTestRunController.php
@@ -26,7 +26,7 @@ class AssetTestRunController extends Controller
             'status' => $request->input('status', 'in_progress'),
             'os_version' => $request->input('os_version'),
             'notes' => $request->input('notes'),
-            'started_at' => $request->input('started_at'),
+            'started_at' => now(),
             'finished_at' => $request->input('finished_at'),
         ]);
         return redirect()->route('hardware.show', $asset);
@@ -35,7 +35,7 @@ class AssetTestRunController extends Controller
     public function update(AssetTestRunRequest $request, AssetTestRun $run): RedirectResponse
     {
         $this->authorize('update', $run);
-        $run->update($request->validated());
+        $run->update($request->safe()->except('started_at'));
         return redirect()->back();
     }
 

--- a/app/Http/Controllers/AssetTestRunController.php
+++ b/app/Http/Controllers/AssetTestRunController.php
@@ -23,7 +23,7 @@ class AssetTestRunController extends Controller
         $this->authorize('create', AssetTestRun::class);
         $run = $asset->testRuns()->create([
             'user_id' => auth()->id(),
-            'test_type' => $request->input('test_type'),
+            'test_type' => $request->input('test_type', 'laptop'),
             'status' => $request->input('status', 'in_progress'),
             'os_version' => $request->input('os_version'),
             'notes' => $request->input('notes'),

--- a/app/Http/Controllers/AssetTestRunController.php
+++ b/app/Http/Controllers/AssetTestRunController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\AssetTestRunRequest;
+use App\Models\Asset;
+use App\Models\AssetTestRun;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class AssetTestRunController extends Controller
+{
+    public function index(Asset $asset)
+    {
+        $this->authorize('viewAny', AssetTestRun::class);
+        $runs = $asset->testRuns()->with('items')->latest()->get();
+        return view('hardware.test-runs.index', compact('asset', 'runs'));
+    }
+
+    public function store(AssetTestRunRequest $request, Asset $asset): RedirectResponse
+    {
+        $this->authorize('create', AssetTestRun::class);
+        $asset->testRuns()->create([
+            'user_id' => auth()->id(),
+            'os_version' => $request->input('os_version'),
+            'notes' => $request->input('notes'),
+            'started_at' => $request->input('started_at'),
+            'finished_at' => $request->input('finished_at'),
+        ]);
+        return redirect()->route('hardware.show', $asset);
+    }
+
+    public function update(AssetTestRunRequest $request, AssetTestRun $run): RedirectResponse
+    {
+        $this->authorize('update', $run);
+        $run->update($request->validated());
+        return redirect()->back();
+    }
+
+    public function destroy(AssetTestRun $run): RedirectResponse
+    {
+        $this->authorize('delete', $run);
+        $run->delete();
+        return redirect()->back();
+    }
+}

--- a/app/Http/Controllers/AssetTestRunController.php
+++ b/app/Http/Controllers/AssetTestRunController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\AssetTestRunRequest;
 use App\Models\Asset;
 use App\Models\AssetTestRun;
+use App\Models\AssetTestItem;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
@@ -20,7 +21,7 @@ class AssetTestRunController extends Controller
     public function store(AssetTestRunRequest $request, Asset $asset): RedirectResponse
     {
         $this->authorize('create', AssetTestRun::class);
-        $asset->testRuns()->create([
+        $run = $asset->testRuns()->create([
             'user_id' => auth()->id(),
             'test_type' => $request->input('test_type'),
             'status' => $request->input('status', 'in_progress'),
@@ -29,6 +30,14 @@ class AssetTestRunController extends Controller
             'started_at' => now(),
             'finished_at' => $request->input('finished_at'),
         ]);
+
+        foreach (AssetTestItem::COMPONENTS as $component) {
+            $run->items()->create([
+                'component' => $component,
+                'status' => 'na',
+            ]);
+        }
+
         return redirect()->route('hardware.show', $asset);
     }
 

--- a/app/Http/Controllers/AssetTestRunController.php
+++ b/app/Http/Controllers/AssetTestRunController.php
@@ -31,10 +31,13 @@ class AssetTestRunController extends Controller
             'finished_at' => $request->input('finished_at'),
         ]);
 
+        $items = $request->input('items', []);
         foreach (AssetTestItem::COMPONENTS as $component) {
+            $data = $items[$component] ?? [];
             $run->items()->create([
                 'component' => $component,
-                'status' => 'na',
+                'status' => $data['status'] ?? 'na',
+                'notes' => $data['notes'] ?? null,
             ]);
         }
 

--- a/app/Http/Controllers/AssetTestRunController.php
+++ b/app/Http/Controllers/AssetTestRunController.php
@@ -22,6 +22,8 @@ class AssetTestRunController extends Controller
         $this->authorize('create', AssetTestRun::class);
         $asset->testRuns()->create([
             'user_id' => auth()->id(),
+            'test_type' => $request->input('test_type'),
+            'status' => $request->input('status', 'in_progress'),
             'os_version' => $request->input('os_version'),
             'notes' => $request->input('notes'),
             'started_at' => $request->input('started_at'),

--- a/app/Http/Controllers/Assets/AssetsController.php
+++ b/app/Http/Controllers/Assets/AssetsController.php
@@ -310,7 +310,9 @@ class AssetsController extends Controller
                 'url' => route('qr_code/hardware', $asset),
             ];
 
-            return view('hardware/view', compact('asset', 'qr_code', 'settings'))
+            $asset->load(['testRuns.items']);
+            $latestRun = $asset->testRuns->sortByDesc('created_at')->first();
+            return view('hardware/view', compact('asset', 'qr_code', 'settings', 'latestRun'))
                 ->with('use_currency', $use_currency)->with('audit_log', $audit_log);
         }
 

--- a/app/Http/Requests/AssetTestItemRequest.php
+++ b/app/Http/Requests/AssetTestItemRequest.php
@@ -16,7 +16,7 @@ class AssetTestItemRequest extends Request
     {
         return [
             'asset_test_run_id' => 'sometimes|exists:asset_test_runs,id',
-            'component' => ['required', Rule::in(AssetTestItem::COMPONENTS)],
+            'component' => 'required|in:' . implode(',', AssetTestItem::COMPONENTS),
             'status' => 'required|in:pass,fail,na',
             'notes' => 'nullable|string',
             'completed_at' => 'nullable|date',

--- a/app/Http/Requests/AssetTestItemRequest.php
+++ b/app/Http/Requests/AssetTestItemRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+class AssetTestItemRequest extends Request
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'asset_test_run_id' => 'sometimes|exists:asset_test_runs,id',
+            'component' => 'required|in:keyboard,screen,touchpad,usb,sd,dvd,vga,hdmi,cpu_stress,battery,ram,webcam,mic,speakers,wifi,bluetooth,ethernet,fingerprint',
+            'status' => 'required|in:pass,fail,na',
+            'notes' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Requests/AssetTestItemRequest.php
+++ b/app/Http/Requests/AssetTestItemRequest.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Models\AssetTestItem;
+use Illuminate\Validation\Rule;
+
 class AssetTestItemRequest extends Request
 {
     public function authorize()
@@ -13,7 +16,7 @@ class AssetTestItemRequest extends Request
     {
         return [
             'asset_test_run_id' => 'sometimes|exists:asset_test_runs,id',
-            'component' => 'required|string',
+            'component' => ['required', Rule::in(AssetTestItem::COMPONENTS)],
             'status' => 'required|in:pass,fail,na',
             'notes' => 'nullable|string',
             'completed_at' => 'nullable|date',

--- a/app/Http/Requests/AssetTestItemRequest.php
+++ b/app/Http/Requests/AssetTestItemRequest.php
@@ -13,9 +13,10 @@ class AssetTestItemRequest extends Request
     {
         return [
             'asset_test_run_id' => 'sometimes|exists:asset_test_runs,id',
-            'component' => 'required|in:keyboard,screen,touchpad,usb,sd,dvd,vga,hdmi,cpu_stress,battery,ram,webcam,mic,speakers,wifi,bluetooth,ethernet,fingerprint',
+            'component' => 'required|string',
             'status' => 'required|in:pass,fail,na',
             'notes' => 'nullable|string',
+            'completed_at' => 'nullable|date',
         ];
     }
 }

--- a/app/Http/Requests/AssetTestRunRequest.php
+++ b/app/Http/Requests/AssetTestRunRequest.php
@@ -16,8 +16,7 @@ class AssetTestRunRequest extends Request
             'status' => 'nullable|in:in_progress,completed',
             'os_version' => 'nullable|string',
             'notes' => 'nullable|string',
-            'started_at' => 'nullable|date',
-            'finished_at' => 'nullable|date|after_or_equal:started_at',
+            'finished_at' => 'nullable|date',
         ];
     }
 }

--- a/app/Http/Requests/AssetTestRunRequest.php
+++ b/app/Http/Requests/AssetTestRunRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests;
+
+class AssetTestRunRequest extends Request
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'os_version' => 'nullable|string',
+            'notes' => 'nullable|string',
+            'started_at' => 'nullable|date',
+            'finished_at' => 'nullable|date|after_or_equal:started_at',
+        ];
+    }
+}

--- a/app/Http/Requests/AssetTestRunRequest.php
+++ b/app/Http/Requests/AssetTestRunRequest.php
@@ -12,7 +12,7 @@ class AssetTestRunRequest extends Request
     public function rules()
     {
         return [
-            'test_type' => 'nullable|string',
+            'test_type' => 'nullable|in:laptop',
             'status' => 'nullable|in:in_progress,completed',
             'os_version' => 'nullable|string',
             'notes' => 'nullable|string',

--- a/app/Http/Requests/AssetTestRunRequest.php
+++ b/app/Http/Requests/AssetTestRunRequest.php
@@ -12,6 +12,8 @@ class AssetTestRunRequest extends Request
     public function rules()
     {
         return [
+            'test_type' => 'nullable|string',
+            'status' => 'nullable|in:in_progress,completed',
             'os_version' => 'nullable|string',
             'notes' => 'nullable|string',
             'started_at' => 'nullable|date',

--- a/app/Http/Requests/AssetTestRunRequest.php
+++ b/app/Http/Requests/AssetTestRunRequest.php
@@ -17,6 +17,9 @@ class AssetTestRunRequest extends Request
             'os_version' => 'nullable|string',
             'notes' => 'nullable|string',
             'finished_at' => 'nullable|date',
+            'items' => 'nullable|array',
+            'items.*.status' => 'nullable|in:pass,fail,na',
+            'items.*.notes' => 'nullable|string',
         ];
     }
 }

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -12,6 +12,7 @@ use App\Models\Traits\Searchable;
 use App\Presenters\Presentable;
 use App\Presenters\AssetPresenter;
 use Carbon\Carbon;
+use App\Models\AssetTestRun;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -760,6 +761,11 @@ class Asset extends Depreciable
     {
         return $this->hasMany(\App\Models\AssetMaintenance::class, 'asset_id')
             ->orderBy('created_at', 'desc');
+    }
+
+    public function testRuns()
+    {
+        return $this->hasMany(AssetTestRun::class);
     }
 
     /**

--- a/app/Models/AssetTestItem.php
+++ b/app/Models/AssetTestItem.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AssetTestItem extends Model
+{
+    protected $fillable = [
+        'asset_test_run_id',
+        'component',
+        'status',
+        'notes',
+    ];
+
+    public function run(): BelongsTo
+    {
+        return $this->belongsTo(AssetTestRun::class, 'asset_test_run_id');
+    }
+}

--- a/app/Models/AssetTestItem.php
+++ b/app/Models/AssetTestItem.php
@@ -7,6 +7,27 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class AssetTestItem extends Model
 {
+    public const COMPONENTS = [
+        'keyboard',
+        'screen',
+        'touchpad',
+        'usb',
+        'sd',
+        'dvd',
+        'vga',
+        'hdmi',
+        'cpu_stress',
+        'battery',
+        'ram',
+        'webcam',
+        'mic',
+        'speakers',
+        'wifi',
+        'bluetooth',
+        'ethernet',
+        'fingerprint',
+    ];
+
     protected $fillable = [
         'asset_test_run_id',
         'component',

--- a/app/Models/AssetTestItem.php
+++ b/app/Models/AssetTestItem.php
@@ -12,6 +12,11 @@ class AssetTestItem extends Model
         'component',
         'status',
         'notes',
+        'completed_at',
+    ];
+
+    protected $casts = [
+        'completed_at' => 'datetime',
     ];
 
     public function run(): BelongsTo

--- a/app/Models/AssetTestRun.php
+++ b/app/Models/AssetTestRun.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class AssetTestRun extends Model
+{
+    protected $fillable = [
+        'asset_id',
+        'user_id',
+        'os_version',
+        'notes',
+        'started_at',
+        'finished_at',
+    ];
+
+    protected $casts = [
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
+    ];
+
+    public function asset(): BelongsTo
+    {
+        return $this->belongsTo(Asset::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(AssetTestItem::class);
+    }
+
+    public function getAllPassedAttribute(): bool
+    {
+        return $this->items->where('status', 'fail')->count() === 0 && $this->items->count() > 0;
+    }
+}

--- a/app/Models/AssetTestRun.php
+++ b/app/Models/AssetTestRun.php
@@ -11,6 +11,8 @@ class AssetTestRun extends Model
     protected $fillable = [
         'asset_id',
         'user_id',
+        'test_type',
+        'status',
         'os_version',
         'notes',
         'started_at',
@@ -20,6 +22,7 @@ class AssetTestRun extends Model
     protected $casts = [
         'started_at' => 'datetime',
         'finished_at' => 'datetime',
+        'status' => 'string',
     ];
 
     public function asset(): BelongsTo

--- a/app/Policies/AssetTestRunPolicy.php
+++ b/app/Policies/AssetTestRunPolicy.php
@@ -17,12 +17,12 @@ class AssetTestRunPolicy
 
     public function viewAny(User $user): bool
     {
-        return $this->hasRole($user, ['refurbisher', 'packer', 'supervisor', 'admin']);
+        return $this->hasRole($user, ['refurbisher', 'admin']);
     }
 
     public function view(User $user, AssetTestRun $run): bool
     {
-        return $this->hasRole($user, ['refurbisher', 'packer', 'supervisor', 'admin']);
+        return $this->hasRole($user, ['refurbisher', 'admin']);
     }
 
     public function create(User $user): bool
@@ -37,6 +37,6 @@ class AssetTestRunPolicy
 
     public function delete(User $user, AssetTestRun $run): bool
     {
-        return $this->hasRole($user, ['packer', 'supervisor', 'admin']);
+        return $this->hasRole($user, ['admin']);
     }
 }

--- a/app/Policies/AssetTestRunPolicy.php
+++ b/app/Policies/AssetTestRunPolicy.php
@@ -17,26 +17,26 @@ class AssetTestRunPolicy
 
     public function viewAny(User $user): bool
     {
-        return $this->hasRole($user, ['refurbisher', 'supervisor', 'admin']);
+        return $this->hasRole($user, ['refurbisher', 'packer', 'supervisor', 'admin']);
     }
 
     public function view(User $user, AssetTestRun $run): bool
     {
-        return $this->hasRole($user, ['refurbisher', 'supervisor', 'admin', 'packer']);
+        return $this->hasRole($user, ['refurbisher', 'packer', 'supervisor', 'admin']);
     }
 
     public function create(User $user): bool
     {
-        return $this->hasRole($user, ['refurbisher', 'admin']);
+        return $this->hasRole($user, ['refurbisher', 'packer', 'supervisor', 'admin']);
     }
 
     public function update(User $user, AssetTestRun $run): bool
     {
-        return $this->hasRole($user, ['refurbisher', 'admin']);
+        return $this->hasRole($user, ['refurbisher', 'packer', 'supervisor', 'admin']);
     }
 
     public function delete(User $user, AssetTestRun $run): bool
     {
-        return $this->hasRole($user, ['refurbisher', 'admin']);
+        return $this->hasRole($user, ['packer', 'supervisor', 'admin']);
     }
 }

--- a/app/Policies/AssetTestRunPolicy.php
+++ b/app/Policies/AssetTestRunPolicy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\AssetTestRun;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class AssetTestRunPolicy
+{
+    use HandlesAuthorization;
+
+    protected function hasRole(User $user, array $roles): bool
+    {
+        return $user->groups()->whereIn('name', $roles)->exists();
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->hasRole($user, ['refurbisher', 'supervisor', 'admin']);
+    }
+
+    public function view(User $user, AssetTestRun $run): bool
+    {
+        return $this->hasRole($user, ['refurbisher', 'supervisor', 'admin', 'packer']);
+    }
+
+    public function create(User $user): bool
+    {
+        return $this->hasRole($user, ['refurbisher', 'admin']);
+    }
+
+    public function update(User $user, AssetTestRun $run): bool
+    {
+        return $this->hasRole($user, ['refurbisher', 'admin']);
+    }
+
+    public function delete(User $user, AssetTestRun $run): bool
+    {
+        return $this->hasRole($user, ['refurbisher', 'admin']);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -20,6 +20,7 @@ use App\Models\PredefinedKit;
 use App\Models\Statuslabel;
 use App\Models\Supplier;
 use App\Models\User;
+use App\Models\AssetTestRun;
 use App\Policies\AccessoryPolicy;
 use App\Policies\AssetModelPolicy;
 use App\Policies\AssetPolicy;
@@ -38,6 +39,7 @@ use App\Policies\PredefinedKitPolicy;
 use App\Policies\StatuslabelPolicy;
 use App\Policies\SupplierPolicy;
 use App\Policies\UserPolicy;
+use App\Policies\AssetTestRunPolicy;
 use Carbon\Carbon;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
@@ -71,6 +73,7 @@ class AuthServiceProvider extends ServiceProvider
         User::class => UserPolicy::class,
         Manufacturer::class => ManufacturerPolicy::class,
         Company::class => CompanyPolicy::class,
+        AssetTestRun::class => AssetTestRunPolicy::class,
     ];
 
     /**

--- a/config/test-runs.php
+++ b/config/test-runs.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'auto_complete' => env('TEST_RUNS_AUTO_COMPLETE', false),
+];

--- a/database/migrations/2025_08_12_055541_create_asset_test_runs_table.php
+++ b/database/migrations/2025_08_12_055541_create_asset_test_runs_table.php
@@ -18,6 +18,8 @@ return new class extends Migration
             $table->unsignedInteger('user_id');
             $table->foreign('asset_id')->references('id')->on('assets')->cascadeOnDelete();
             $table->foreign('user_id')->references('id')->on('users')->restrictOnDelete();
+            $table->string('test_type')->nullable();
+            $table->enum('status', ['in_progress', 'completed'])->default('in_progress');
             $table->string('os_version')->nullable();
             $table->text('notes')->nullable();
             $table->dateTime('started_at')->nullable();

--- a/database/migrations/2025_08_12_055541_create_asset_test_runs_table.php
+++ b/database/migrations/2025_08_12_055541_create_asset_test_runs_table.php
@@ -9,6 +9,16 @@ return new class extends Migration
     public function up(): void
     {
         if (Schema::hasTable('asset_test_runs')) {
+            Schema::table('asset_test_runs', function (Blueprint $table) {
+                if (!Schema::hasColumn('asset_test_runs', 'test_type')) {
+                    $table->string('test_type')->nullable()->after('user_id');
+                }
+
+                if (!Schema::hasColumn('asset_test_runs', 'status')) {
+                    $table->enum('status', ['in_progress', 'completed'])->default('in_progress')->after('test_type');
+                }
+            });
+
             return;
         }
 

--- a/database/migrations/2025_08_12_055541_create_asset_test_runs_table.php
+++ b/database/migrations/2025_08_12_055541_create_asset_test_runs_table.php
@@ -23,11 +23,11 @@ return new class extends Migration
         }
 
         Schema::create('asset_test_runs', function (Blueprint $table) {
-            $table->id();
+            $table->increments('id');
             $table->unsignedInteger('asset_id');
             $table->unsignedInteger('user_id');
-            $table->foreign('asset_id')->references('id')->on('assets')->cascadeOnDelete();
-            $table->foreign('user_id')->references('id')->on('users')->restrictOnDelete();
+            $table->foreign('asset_id')->references('id')->on('assets')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('restrict');
             $table->string('test_type')->nullable();
             $table->enum('status', ['in_progress', 'completed'])->default('in_progress');
             $table->string('os_version')->nullable();

--- a/database/migrations/2025_08_12_055541_create_asset_test_runs_table.php
+++ b/database/migrations/2025_08_12_055541_create_asset_test_runs_table.php
@@ -10,8 +10,10 @@ return new class extends Migration
     {
         Schema::create('asset_test_runs', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('asset_id')->constrained('assets')->cascadeOnDelete();
-            $table->foreignId('user_id')->constrained('users')->restrictOnDelete();
+            $table->unsignedInteger('asset_id');
+            $table->unsignedInteger('user_id');
+            $table->foreign('asset_id')->references('id')->on('assets')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->restrictOnDelete();
             $table->string('os_version')->nullable();
             $table->text('notes')->nullable();
             $table->dateTime('started_at')->nullable();

--- a/database/migrations/2025_08_12_055541_create_asset_test_runs_table.php
+++ b/database/migrations/2025_08_12_055541_create_asset_test_runs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('asset_test_runs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('asset_id')->constrained('assets')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->restrictOnDelete();
+            $table->string('os_version')->nullable();
+            $table->text('notes')->nullable();
+            $table->dateTime('started_at')->nullable();
+            $table->dateTime('finished_at')->nullable();
+            $table->timestamps();
+            $table->index('asset_id');
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('asset_test_runs');
+    }
+};

--- a/database/migrations/2025_08_12_055541_create_asset_test_runs_table.php
+++ b/database/migrations/2025_08_12_055541_create_asset_test_runs_table.php
@@ -8,6 +8,10 @@ return new class extends Migration
 {
     public function up(): void
     {
+        if (Schema::hasTable('asset_test_runs')) {
+            return;
+        }
+
         Schema::create('asset_test_runs', function (Blueprint $table) {
             $table->id();
             $table->unsignedInteger('asset_id');

--- a/database/migrations/2025_08_12_055543_create_asset_test_items_table.php
+++ b/database/migrations/2025_08_12_055543_create_asset_test_items_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('asset_test_run_id')->constrained('asset_test_runs')->cascadeOnDelete();
             $table->string('component');
-            $table->enum('status', ['pass','fail','na']);
+            $table->enum('status', ['pass','fail','na'])->default('na');
             $table->text('notes')->nullable();
             $table->timestamp('completed_at')->nullable();
             $table->timestamps();

--- a/database/migrations/2025_08_12_055543_create_asset_test_items_table.php
+++ b/database/migrations/2025_08_12_055543_create_asset_test_items_table.php
@@ -19,8 +19,9 @@ return new class extends Migration
         }
 
         Schema::create('asset_test_items', function (Blueprint $table) {
-            $table->id();
-            $table->foreignId('asset_test_run_id')->constrained('asset_test_runs')->cascadeOnDelete();
+            $table->increments('id');
+            $table->unsignedInteger('asset_test_run_id');
+            $table->foreign('asset_test_run_id')->references('id')->on('asset_test_runs')->onDelete('cascade');
             $table->string('component');
             $table->enum('status', ['pass','fail','na'])->default('na');
             $table->text('notes')->nullable();

--- a/database/migrations/2025_08_12_055543_create_asset_test_items_table.php
+++ b/database/migrations/2025_08_12_055543_create_asset_test_items_table.php
@@ -9,6 +9,12 @@ return new class extends Migration
     public function up(): void
     {
         if (Schema::hasTable('asset_test_items')) {
+            Schema::table('asset_test_items', function (Blueprint $table) {
+                if (!Schema::hasColumn('asset_test_items', 'completed_at')) {
+                    $table->timestamp('completed_at')->nullable()->after('notes');
+                }
+            });
+
             return;
         }
 

--- a/database/migrations/2025_08_12_055543_create_asset_test_items_table.php
+++ b/database/migrations/2025_08_12_055543_create_asset_test_items_table.php
@@ -18,6 +18,7 @@ return new class extends Migration
             $table->string('component');
             $table->enum('status', ['pass','fail','na']);
             $table->text('notes')->nullable();
+            $table->timestamp('completed_at')->nullable();
             $table->timestamps();
             $table->index(['asset_test_run_id', 'component']);
         });

--- a/database/migrations/2025_08_12_055543_create_asset_test_items_table.php
+++ b/database/migrations/2025_08_12_055543_create_asset_test_items_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('asset_test_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('asset_test_run_id')->constrained('asset_test_runs')->cascadeOnDelete();
+            $table->string('component');
+            $table->enum('status', ['pass','fail','na']);
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->index(['asset_test_run_id', 'component']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('asset_test_items');
+    }
+};

--- a/database/migrations/2025_08_12_055543_create_asset_test_items_table.php
+++ b/database/migrations/2025_08_12_055543_create_asset_test_items_table.php
@@ -8,6 +8,10 @@ return new class extends Migration
 {
     public function up(): void
     {
+        if (Schema::hasTable('asset_test_items')) {
+            return;
+        }
+
         Schema::create('asset_test_items', function (Blueprint $table) {
             $table->id();
             $table->foreignId('asset_test_run_id')->constrained('asset_test_runs')->cascadeOnDelete();

--- a/database/migrations/2025_08_20_000000_add_test_type_and_status_to_asset_test_runs_table.php
+++ b/database/migrations/2025_08_20_000000_add_test_type_and_status_to_asset_test_runs_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('asset_test_runs', function (Blueprint $table) {
+            if (!Schema::hasColumn('asset_test_runs', 'test_type')) {
+                $table->string('test_type')->nullable()->after('user_id');
+            }
+
+            if (!Schema::hasColumn('asset_test_runs', 'status')) {
+                $table->enum('status', ['in_progress', 'completed'])->default('in_progress')->after('test_type');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('asset_test_runs', function (Blueprint $table) {
+            if (Schema::hasColumn('asset_test_runs', 'status')) {
+                $table->dropColumn('status');
+            }
+
+            if (Schema::hasColumn('asset_test_runs', 'test_type')) {
+                $table->dropColumn('test_type');
+            }
+        });
+    }
+};

--- a/docs/repeatable-tests.md
+++ b/docs/repeatable-tests.md
@@ -22,11 +22,12 @@ PATCH /api/v1/test-runs/{run}/items/{item}
 Run payload example:
 ```json
 {
-  "test_type": "mobile",
+  "test_type": "laptop",
   "status": "in_progress",
   "os_version": "Ubuntu 22.04"
 }
 ```
+`test_type` defaults to `laptop`; additional types may be added later.
 `started_at` is set automatically when the run is created.
 
 Item payload example:

--- a/docs/repeatable-tests.md
+++ b/docs/repeatable-tests.md
@@ -37,3 +37,28 @@ Item payload example:
   "completed_at": "2025-01-01T10:15:00Z"
 }
 ```
+
+## Component whitelist
+
+The API and UI accept the following component names for laptop and desktop tests:
+
+- `keyboard`
+- `screen`
+- `touchpad`
+- `usb`
+- `sd`
+- `dvd`
+- `vga`
+- `hdmi`
+- `cpu_stress`
+- `battery`
+- `ram`
+- `webcam`
+- `mic`
+- `speakers`
+- `wifi`
+- `bluetooth`
+- `ethernet`
+- `fingerprint`
+
+Components outside this list are rejected during validation.

--- a/docs/repeatable-tests.md
+++ b/docs/repeatable-tests.md
@@ -5,7 +5,7 @@ This feature lets refurbishers record hardware test runs on assets.
 ## Web UI
 * Open an asset detail page and select the **Tests** tab.
 * Use **Nieuwe testrun** to log a run and record component results.
-* A green banner "Alle tests geslaagd" appears when the latest run has no failures.
+* A green banner "Alle tests geslaagd" appears when the latest completed run has no failures.
 
 ## API
 ```
@@ -22,7 +22,18 @@ PATCH /api/v1/test-runs/{run}/items/{item}
 Run payload example:
 ```json
 {
+  "test_type": "mobile",
+  "status": "in_progress",
   "os_version": "Ubuntu 22.04",
   "started_at": "2025-01-01T10:00:00Z"
+}
+```
+
+Item payload example:
+```json
+{
+  "component": "keyboard",
+  "status": "pass",
+  "completed_at": "2025-01-01T10:15:00Z"
 }
 ```

--- a/docs/repeatable-tests.md
+++ b/docs/repeatable-tests.md
@@ -24,10 +24,10 @@ Run payload example:
 {
   "test_type": "mobile",
   "status": "in_progress",
-  "os_version": "Ubuntu 22.04",
-  "started_at": "2025-01-01T10:00:00Z"
+  "os_version": "Ubuntu 22.04"
 }
 ```
+`started_at` is set automatically when the run is created.
 
 Item payload example:
 ```json

--- a/docs/repeatable-tests.md
+++ b/docs/repeatable-tests.md
@@ -1,0 +1,28 @@
+# Repeatable Asset Tests
+
+This feature lets refurbishers record hardware test runs on assets.
+
+## Web UI
+* Open an asset detail page and select the **Tests** tab.
+* Use **Nieuwe testrun** to log a run and record component results.
+* A green banner "Alle tests geslaagd" appears when the latest run has no failures.
+
+## API
+```
+GET  /api/v1/assets/{asset}/test-runs
+POST /api/v1/assets/{asset}/test-runs
+GET  /api/v1/test-runs/{run}
+PATCH /api/v1/test-runs/{run}
+DELETE /api/v1/test-runs/{run}
+GET  /api/v1/test-runs/{run}/items
+POST /api/v1/test-runs/{run}/items
+PATCH /api/v1/test-runs/{run}/items/{item}
+```
+
+Run payload example:
+```json
+{
+  "os_version": "Ubuntu 22.04",
+  "started_at": "2025-01-01T10:00:00Z"
+}
+```

--- a/resources/views/hardware/test-runs/index.blade.php
+++ b/resources/views/hardware/test-runs/index.blade.php
@@ -7,7 +7,9 @@ Test runs
 <div class="container">
     <ul class="list-group">
         @foreach($runs as $run)
-            <li class="list-group-item">{{ $run->created_at }}</li>
+            <li class="list-group-item">
+                {{ $run->created_at }} - {{ $run->status }}
+            </li>
         @endforeach
     </ul>
 </div>

--- a/resources/views/hardware/test-runs/index.blade.php
+++ b/resources/views/hardware/test-runs/index.blade.php
@@ -1,0 +1,14 @@
+@extends('layouts/default')
+@section('title')
+Test runs
+@parent
+@stop
+@section('content')
+<div class="container">
+    <ul class="list-group">
+        @foreach($runs as $run)
+            <li class="list-group-item">{{ $run->created_at }}</li>
+        @endforeach
+    </ul>
+</div>
+@stop

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -46,6 +46,14 @@
             </div>
         @endif
 
+        @if ($latestRun && $latestRun->all_passed)
+            <div class="col-md-12">
+                <div class="callout callout-success">
+                    Alle tests geslaagd
+                </div>
+            </div>
+        @endif
+
         <div class="col-md-12">
             <div class="nav-tabs-custom">
                 <ul class="nav nav-tabs hidden-print">
@@ -144,6 +152,17 @@
                           </span>
                             <span class="hidden-xs hidden-sm">{{ trans('general.maintenances') }}
                                 {!! ($asset->assetmaintenances()->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->assetmaintenances()->count()).'</span>' : '' !!}
+                          </span>
+                        </a>
+                    </li>
+
+                    <li>
+                        <a href="#tests" data-toggle="tab">
+                          <span class="hidden-lg hidden-md">
+                              <i class="fas fa-vial fa-2x"></i>
+                          </span>
+                            <span class="hidden-xs hidden-sm">Tests
+                                {!! ($asset->testRuns->count() > 0 ) ? '<span class="badge badge-secondary">'.number_format($asset->testRuns->count()).'</span>' : '' !!}
                           </span>
                         </a>
                     </li>
@@ -1414,6 +1433,29 @@
                         </div> <!-- /.row -->
                     </div> <!-- /.tab-pane history -->
 
+                    <div class="tab-pane fade" id="tests">
+                        @can('create', \App\Models\AssetTestRun::class)
+                            <button class="btn btn-primary" data-toggle="modal" data-target="#newTestRunModal">Nieuwe testrun</button>
+                        @endcan
+                        <ul class="list-group mt-3">
+                        @foreach($asset->testRuns->sortByDesc('created_at') as $run)
+                            <li class="list-group-item">
+                                {{ Helper::getFormattedDateObject($run->created_at, 'datetime', false) }}
+                                @if($run->all_passed)
+                                    <span class="badge badge-success">OK</span>
+                                @else
+                                    <span class="badge badge-danger">FAIL</span>
+                                @endif
+                                <ul>
+                                    @foreach($run->items as $item)
+                                        <li>{{ $item->component }}: {{ $item->status }}</li>
+                                    @endforeach
+                                </ul>
+                            </li>
+                        @endforeach
+                        </ul>
+                    </div>
+
                     <div class="tab-pane fade" id="files">
                         <div class="row{{ ($asset->uploads->count() > 0 ) ? '' : ' hidden-print' }}">
                             <div class="col-md-12">
@@ -1435,6 +1477,32 @@
                     @endif
             </div><!-- /.tab-content -->
         </div><!-- nav-tabs-custom -->
+    </div>
+
+    <div class="modal fade" id="newTestRunModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <form method="POST" action="{{ route('hardware.test-runs.store', $asset) }}">
+                    @csrf
+                    <div class="modal-header">
+                        <h4 class="modal-title">Nieuwe testrun</h4>
+                    </div>
+                    <div class="modal-body">
+                        <div class="form-group">
+                            <label>OS Version</label>
+                            <input type="text" name="os_version" class="form-control">
+                        </div>
+                        <div class="form-group">
+                            <label>Started at</label>
+                            <input type="datetime-local" name="started_at" class="form-control">
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="submit" class="btn btn-primary">{{ trans('general.save') }}</button>
+                    </div>
+                </form>
+            </div>
+        </div>
     </div>
 
     @can('update', \App\Models\Asset::class)

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1502,6 +1502,32 @@
                             <label>Notities</label>
                             <textarea name="notes" class="form-control" rows="3"></textarea>
                         </div>
+                        <table class="table table-sm">
+                            <thead>
+                                <tr>
+                                    <th>Component</th>
+                                    <th>Status</th>
+                                    <th>Opmerking</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach(\App\Models\AssetTestItem::COMPONENTS as $component)
+                                    <tr>
+                                        <td>{{ ucfirst(str_replace('_', ' ', $component)) }}</td>
+                                        <td>
+                                            <select name="items[{{ $component }}][status]" class="form-control">
+                                                <option value="pass">Pass</option>
+                                                <option value="fail">Fail</option>
+                                                <option value="na" selected>N.v.t.</option>
+                                            </select>
+                                        </td>
+                                        <td>
+                                            <input type="text" name="items[{{ $component }}][notes]" class="form-control">
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
                     </div>
                     <div class="modal-footer">
                         <button type="submit" class="btn btn-primary">{{ trans('general.save') }}</button>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1496,7 +1496,9 @@
                         </div>
                         <div class="form-group">
                             <label>Test Type</label>
-                            <input type="text" name="test_type" class="form-control">
+                            <select name="test_type" class="form-control">
+                                <option value="laptop" selected>Laptop</option>
+                            </select>
                         </div>
                         <div class="form-group">
                             <label>Notities</label>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1499,6 +1499,10 @@
                             <input type="text" name="test_type" class="form-control">
                         </div>
                         <div class="form-group">
+                            <label>Notities</label>
+                            <textarea name="notes" class="form-control" rows="3"></textarea>
+                        </div>
+                        <div class="form-group">
                             <label>Started at</label>
                             <input type="datetime-local" name="started_at" class="form-control">
                         </div>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -1502,10 +1502,6 @@
                             <label>Notities</label>
                             <textarea name="notes" class="form-control" rows="3"></textarea>
                         </div>
-                        <div class="form-group">
-                            <label>Started at</label>
-                            <input type="datetime-local" name="started_at" class="form-control">
-                        </div>
                     </div>
                     <div class="modal-footer">
                         <button type="submit" class="btn btn-primary">{{ trans('general.save') }}</button>

--- a/resources/views/hardware/view.blade.php
+++ b/resources/views/hardware/view.blade.php
@@ -46,7 +46,7 @@
             </div>
         @endif
 
-        @if ($latestRun && $latestRun->all_passed)
+        @if ($latestRun && $latestRun->status === 'completed' && $latestRun->all_passed)
             <div class="col-md-12">
                 <div class="callout callout-success">
                     Alle tests geslaagd
@@ -1440,11 +1440,13 @@
                         <ul class="list-group mt-3">
                         @foreach($asset->testRuns->sortByDesc('created_at') as $run)
                             <li class="list-group-item">
-                                {{ Helper::getFormattedDateObject($run->created_at, 'datetime', false) }}
-                                @if($run->all_passed)
-                                    <span class="badge badge-success">OK</span>
-                                @else
-                                    <span class="badge badge-danger">FAIL</span>
+                                {{ Helper::getFormattedDateObject($run->created_at, 'datetime', false) }} - {{ $run->status }}
+                                @if($run->status === 'completed')
+                                    @if($run->all_passed)
+                                        <span class="badge badge-success">OK</span>
+                                    @else
+                                        <span class="badge badge-danger">FAIL</span>
+                                    @endif
                                 @endif
                                 <ul>
                                     @foreach($run->items as $item)
@@ -1491,6 +1493,10 @@
                         <div class="form-group">
                             <label>OS Version</label>
                             <input type="text" name="os_version" class="form-control">
+                        </div>
+                        <div class="form-group">
+                            <label>Test Type</label>
+                            <input type="text" name="test_type" class="form-control">
                         </div>
                         <div class="form-group">
                             <label>Started at</label>

--- a/routes/api.php
+++ b/routes/api.php
@@ -602,7 +602,7 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
         /**
          * Asset maintenances API routes
          */
-        Route::resource('maintenances', 
+        Route::resource('maintenances',
         Api\AssetMaintenancesController::class,
         ['names' => [
                 'index' => 'api.maintenances.index',
@@ -615,6 +615,16 @@ Route::group(['prefix' => 'v1', 'middleware' => ['api', 'api-throttle:api']], fu
         'parameters' => ['maintenance' => 'maintenance_id'],
         ]
         ); // end assets API routes
+
+        // Asset test runs API routes
+        Route::get('assets/{asset}/test-runs', [Api\AssetTestRunsController::class, 'index']);
+        Route::post('assets/{asset}/test-runs', [Api\AssetTestRunsController::class, 'store']);
+        Route::get('test-runs/{run}', [Api\AssetTestRunsController::class, 'show']);
+        Route::patch('test-runs/{run}', [Api\AssetTestRunsController::class, 'update']);
+        Route::delete('test-runs/{run}', [Api\AssetTestRunsController::class, 'destroy']);
+        Route::get('test-runs/{run}/items', [Api\AssetTestRunsController::class, 'items']);
+        Route::post('test-runs/{run}/items', [Api\AssetTestRunsController::class, 'storeItem']);
+        Route::patch('test-runs/{run}/items/{item}', [Api\AssetTestRunsController::class, 'updateItem']);
 
 
       /**

--- a/routes/web/hardware.php
+++ b/routes/web/hardware.php
@@ -10,6 +10,7 @@ use App\Models\Setting;
 use Tabuna\Breadcrumbs\Trail;
 use Illuminate\Support\Facades\Route;
 use App\Models\Asset;
+use App\Http\Controllers\AssetTestRunController;
 
 /*
 |--------------------------------------------------------------------------
@@ -185,6 +186,12 @@ Route::group(
         Route::post('bulkcheckout',
             [BulkAssetsController::class, 'storeCheckout']
         )->name('hardware.bulkcheckout.store');
+
+        // Asset test runs
+        Route::get('{asset}/tests', [AssetTestRunController::class, 'index'])->name('hardware.test-runs.index');
+        Route::post('{asset}/tests', [AssetTestRunController::class, 'store'])->name('hardware.test-runs.store');
+        Route::patch('tests/{run}', [AssetTestRunController::class, 'update'])->name('hardware.test-runs.update');
+        Route::delete('tests/{run}', [AssetTestRunController::class, 'destroy'])->name('hardware.test-runs.destroy');
 
     });
 

--- a/tests/Feature/AssetTestRuns/AssetTestRunTest.php
+++ b/tests/Feature/AssetTestRuns/AssetTestRunTest.php
@@ -14,6 +14,12 @@ class AssetTestRunTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['auth.guards.api.driver' => 'session']);
+    }
+
     protected function createUserWithRole(string $role): User
     {
         $group = Group::create(['name' => $role]);
@@ -32,7 +38,7 @@ class AssetTestRunTest extends TestCase
         ])->assertRedirect();
 
         $run = AssetTestRun::first();
-        $this->actingAs($user)->postJson('/api/v1/test-runs/'.$run->id.'/items', [
+        $this->actingAs($user, 'api')->postJson('/api/v1/test-runs/'.$run->id.'/items', [
             'component' => 'keyboard',
             'status' => 'pass',
         ])->assertStatus(201);

--- a/tests/Feature/AssetTestRuns/AssetTestRunTest.php
+++ b/tests/Feature/AssetTestRuns/AssetTestRunTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\AssetTestRuns;
+
+use App\Models\Asset;
+use App\Models\AssetTestRun;
+use App\Models\AssetTestItem;
+use App\Models\Group;
+use App\Models\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class AssetTestRunTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function createUserWithRole(string $role): User
+    {
+        $group = Group::create(['name' => $role]);
+        $user = User::factory()->create();
+        $user->groups()->attach($group);
+        return $user;
+    }
+
+    public function test_refurbisher_can_create_run_and_items(): void
+    {
+        $user = $this->createUserWithRole('refurbisher');
+        $asset = Asset::factory()->create();
+
+        $this->actingAs($user)->post(route('hardware.test-runs.store', $asset), [
+            'os_version' => '1.0',
+        ])->assertRedirect();
+
+        $run = AssetTestRun::first();
+        $this->actingAs($user)->postJson('/api/v1/test-runs/'.$run->id.'/items', [
+            'component' => 'keyboard',
+            'status' => 'pass',
+        ])->assertStatus(201);
+
+        $this->assertTrue($run->fresh()->all_passed);
+    }
+
+    public function test_packer_cannot_create_run(): void
+    {
+        $user = $this->createUserWithRole('packer');
+        $asset = Asset::factory()->create();
+
+        $this->actingAs($user)->post(route('hardware.test-runs.store', $asset), [
+            'os_version' => '1.0',
+        ])->assertForbidden();
+    }
+
+    public function test_all_passed_false_with_fail(): void
+    {
+        $user = $this->createUserWithRole('refurbisher');
+        $asset = Asset::factory()->create();
+        $run = AssetTestRun::create([
+            'asset_id' => $asset->id,
+            'user_id' => $user->id,
+        ]);
+        AssetTestItem::create([
+            'asset_test_run_id' => $run->id,
+            'component' => 'keyboard',
+            'status' => 'fail',
+        ]);
+        $this->assertFalse($run->fresh()->all_passed);
+    }
+}


### PR DESCRIPTION
## Summary
- add asset_test_runs and asset_test_items tables
- expose repeatable test run models, policies, controllers and routes
- add Tests tab on asset detail with run list and creation modal
- document UI and API usage

## Testing
- `php artisan test tests/Feature/AssetTestRuns/AssetTestRunTest.php` *(fails: Invalid key supplied)*


------
https://chatgpt.com/codex/tasks/task_e_689ad6660e8c832d8986b25d79d69f26